### PR TITLE
Update vite-plugin-glsl version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build", 
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {
@@ -39,7 +39,7 @@
     "parcel": "^2.7.0",
     "parcel-plugin-vite": "^1.0.2",
     "vite": "^3.1.6",
-    "vite-plugin-glsl": "^0.4.0"
+    "vite-plugin-glsl": "^0.5.3"
   },
   "dependencies": {
     "lil-gui": "^0.17.0",


### PR DESCRIPTION
Update *vite-plugin-glsl* to `v0.5.3` since it introduces new `watch` option (`true` by default) for shaders hot reloading when a chunk file was updated and saved. Tested with shaders within this repo and with the ones in the *lygia* submodule.