### PR TITLE
Proposal: use "root" option to include lygia shaders implicitly 

### DIFF
--- a/src/glsl/animation_easing.frag
+++ b/src/glsl/animation_easing.frag
@@ -8,11 +8,11 @@ uniform float   u_time;
 
 varying vec2    v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/space/scale.glsl"
-#include "lygia/animation/easing.glsl"
-#include "lygia/draw/circle.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/space/ratio.glsl"
+#include "/space/scale.glsl"
+#include "/animation/easing.glsl"
+#include "/draw/circle.glsl"
+#include "/draw/rect.glsl"
 
 void main(void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/animation_sprite.frag
+++ b/src/glsl/animation_sprite.frag
@@ -11,11 +11,11 @@ uniform float       u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/math/decimation.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/space/scale.glsl"
-#include "lygia/animation/spriteLoop.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/math/decimation.glsl"
+#include "/space/ratio.glsl"
+#include "/space/scale.glsl"
+#include "/animation/spriteLoop.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec4 color = vec4(0.0, 0.0, 0.0, 1.0);

--- a/src/glsl/color_dither.frag
+++ b/src/glsl/color_dither.frag
@@ -10,7 +10,7 @@ uniform float       u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
+#include "/space/ratio.glsl"
 
 // #define DITHER_FNC ditherShift
 // #define DITHER_FNC ditherVlachos
@@ -22,7 +22,7 @@ varying vec2        v_texcoord;
 
 #define TIME_SECS u_time
 #define BLUENOISE_TEXTURE u_noiseTex
-#include "lygia/color/dither.glsl"
+#include "/color/dither.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/color_lut.frag
+++ b/src/glsl/color_lut.frag
@@ -11,15 +11,15 @@ uniform float       u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
+#include "/space/ratio.glsl"
 
 #define LUT_SQUARE
 #define LUT_FLIP_Y
 #define LUT_CELL_SIZE 64.0
 #define LUT_CELLS_PER_SIDE 8.0
-#include "lygia/color/lut.glsl"
+#include "/color/lut.glsl"
 
-#include "lygia/draw/rect.glsl"
+#include "/draw/rect.glsl"
 
 void main(void) {
     vec4 color = vec4(0.0);

--- a/src/glsl/default.frag
+++ b/src/glsl/default.frag
@@ -9,8 +9,8 @@ uniform float 		u_time;
 varying vec3 		v_position;
 varying vec2 		v_texcoord;
 
-#include "lygia/math/const.glsl"
-#include "lygia/space/ratio.glsl"
+#include "/math/const.glsl"
+#include "/space/ratio.glsl"
 
 void main()	{
 	vec4 color = vec4(0.0, 0.0, 0.0, 1.0);

--- a/src/glsl/filter_bilateralBlur2D.frag
+++ b/src/glsl/filter_bilateralBlur2D.frag
@@ -11,11 +11,11 @@ uniform sampler2D   u_tex0;
 varying vec2        v_texcoord;
 
 #define BILATERALBLUR_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.01), vec2(0.99)))
-#include "lygia/filter/bilateralBlur.glsl"
+#include "/filter/bilateralBlur.glsl"
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_boxBlur2D.frag
+++ b/src/glsl/filter_boxBlur2D.frag
@@ -12,10 +12,10 @@ varying vec2        v_texcoord;
 
 #define BOXBLUR_2D
 #define BOXBLUR_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.01), vec2(0.99)))
-#include "lygia/filter/boxBlur.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/filter/boxBlur.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_edge2D.frag
+++ b/src/glsl/filter_edge2D.frag
@@ -11,10 +11,10 @@ uniform float       u_time;
 varying vec2        v_texcoord;
 
 #define EDGE_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.02), vec2(0.98))).r
-#include "lygia/filter/edge.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/filter/edge.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_fibonacciBokeh.frag
+++ b/src/glsl/filter_fibonacciBokeh.frag
@@ -10,10 +10,10 @@ uniform float       u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/filter/fibonacciBokeh.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/filter/fibonacciBokeh.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_gaussianBlur2D.frag
+++ b/src/glsl/filter_gaussianBlur2D.frag
@@ -12,10 +12,10 @@ varying vec2        v_texcoord;
 
 #define GAUSSIANBLUR_2D
 #define GAUSSIANBLUR_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.01), vec2(0.99)))
-#include "lygia/filter/gaussianBlur.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/filter/gaussianBlur.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_kuwahara2D.frag
+++ b/src/glsl/filter_kuwahara2D.frag
@@ -11,10 +11,10 @@ uniform float       u_time;
 varying vec2        v_texcoord;
 
 #define KUWAHARA_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.01), vec2(0.99)))
-#include "lygia/filter/kuwahara.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/filter/kuwahara.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_laplacian2D.frag
+++ b/src/glsl/filter_laplacian2D.frag
@@ -11,10 +11,10 @@ uniform float       u_time;
 varying vec2        v_texcoord;
 
 #define LAPLACIAN_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.02), vec2(0.98)))
-#include "lygia/filter/laplacian.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/filter/laplacian.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_median2D.frag
+++ b/src/glsl/filter_median2D.frag
@@ -11,11 +11,11 @@ uniform float       u_time;
 varying vec2        v_texcoord;
 
 #define MEDIAN_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.01), vec2(0.99)))
-#include "lygia/filter/median.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/stroke.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/filter/median.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/stroke.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_noiseBlur2D.frag
+++ b/src/glsl/filter_noiseBlur2D.frag
@@ -11,10 +11,10 @@ uniform float       u_time;
 varying vec2        v_texcoord;
 
 #define NOISEBLUR_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.02), vec2(0.98)))
-#include "lygia/filter/noiseBlur.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/draw/digits.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/filter/noiseBlur.glsl"
+#include "/space/ratio.glsl"
+#include "/draw/digits.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_radialBlur2D.frag
+++ b/src/glsl/filter_radialBlur2D.frag
@@ -11,10 +11,10 @@ uniform float       u_time;
 varying vec2        v_texcoord;
 
 #define RADIALBLUR_SAMPLER_FNC(POS_UV) texture2D(tex, clamp(POS_UV, vec2(0.01), vec2(0.99)))
-#include "lygia/filter/radialBlur.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/math/decimation.glsl"
-#include "lygia/draw/digits.glsl"
+#include "/filter/radialBlur.glsl"
+#include "/space/ratio.glsl"
+#include "/math/decimation.glsl"
+#include "/draw/digits.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/filter_sharpen2D.frag
+++ b/src/glsl/filter_sharpen2D.frag
@@ -10,9 +10,9 @@ uniform float       u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/filter/sharpen.glsl"
-#include "lygia/draw/rect.glsl"
+#include "/space/ratio.glsl"
+#include "/filter/sharpen.glsl"
+#include "/draw/rect.glsl"
 
 void main (void) {
     vec3 color = vec3(0.0);

--- a/src/glsl/generative_cnoise.frag
+++ b/src/glsl/generative_cnoise.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/cnoise.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/cnoise.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_curl.frag
+++ b/src/glsl/generative_curl.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/curl.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/curl.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_fbm.frag
+++ b/src/glsl/generative_fbm.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/fbm.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/fbm.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_noised.frag
+++ b/src/glsl/generative_noised.frag
@@ -6,8 +6,8 @@ precision mediump float;
 uniform vec2    u_resolution;
 uniform float   u_time;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/noised.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/noised.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_pnoise.frag
+++ b/src/glsl/generative_pnoise.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/pnoise.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/pnoise.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_random.frag
+++ b/src/glsl/generative_random.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/random.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/random.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_snoise.frag
+++ b/src/glsl/generative_snoise.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/snoise.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/snoise.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_voronoi.frag
+++ b/src/glsl/generative_voronoi.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/voronoi.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/voronoi.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_voronoise.frag
+++ b/src/glsl/generative_voronoise.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/voronoise.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/voronoise.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/generative_worley.frag
+++ b/src/glsl/generative_worley.frag
@@ -8,8 +8,8 @@ uniform float   u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/worley.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/worley.glsl"
 
 void main(void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/sample_bracketing.frag
+++ b/src/glsl/sample_bracketing.frag
@@ -11,16 +11,16 @@ uniform float       u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/math/const.glsl"
-#include "lygia/math/decimation.glsl"
-#include "lygia/space/ratio.glsl"
-#include "lygia/generative/noised.glsl"
+#include "/math/const.glsl"
+#include "/math/decimation.glsl"
+#include "/space/ratio.glsl"
+#include "/generative/noised.glsl"
 
 #define ARROWS_LINE_STYLE
-#include "lygia/draw/arrows.glsl"
+#include "/draw/arrows.glsl"
 
 #define TEXTUREBRACKETING_REPLACE_DIVERGENCE
-#include "lygia/sample/bracketing.glsl"
+#include "/sample/bracketing.glsl"
 
 void main (void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/src/glsl/sample_untile.frag
+++ b/src/glsl/sample_untile.frag
@@ -11,9 +11,9 @@ uniform float       u_time;
 
 varying vec2        v_texcoord;
 
-#include "lygia/space/ratio.glsl"
+#include "/space/ratio.glsl"
 // #define SAMPLEUNTILE_FAST
-#include "lygia/sample/untile.glsl"
+#include "/sample/untile.glsl"
 
 void main (void) {
     vec4 color = vec4(vec3(0.0), 1.0);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,11 @@
 import glsl from 'vite-plugin-glsl';
 import { defineConfig } from 'vite';
 
-export default defineConfig({
+export default ({ mode }) => defineConfig({
     build: { sourcemap: true },
-    plugins: [glsl()]
+    plugins: [glsl({
+        compress: mode === 'production',
+        warnDuplicatedImports: false,
+        root: '/src/glsl/lygia'
+    })]
 });


### PR DESCRIPTION
By setting `root: '/src/glsl/lygia'` in *vite-plugin-glsl* options it's possible to use *lygia* submodule as a default root directory. It's a little bit less intuitive than specifying relative shader path for each import, so I'm still not sure if this is a good idea, but if you like it, it's possible shorten a bit the include path and mention this setting somewhere in `README` file.